### PR TITLE
fix: rails の 開発環境と本番環境のタイムゾーンを揃えるように修正

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update -qq && \
 
 WORKDIR /back
 
+ENV TZ=Asia/Tokyo
+
 COPY Gemfile /back/Gemfile
 COPY Gemfile.lock /back/Gemfile.lock
 RUN bundle install

--- a/back/Dockerfile.prd
+++ b/back/Dockerfile.prd
@@ -1,6 +1,7 @@
 FROM ruby:2.7.2
 
-ENV RAILS_ENV=production
+ENV RAILS_ENV=production \
+    TZ=Asia/Tokyo
 
 RUN apt-get update -qq && \
     apt-get install -y nodejs \

--- a/back/app/controllers/api/v1/tasks_controller.rb
+++ b/back/app/controllers/api/v1/tasks_controller.rb
@@ -38,7 +38,6 @@ module Api
           from = TaskTemplate::BASEWEEK[today].to_date
           to = TaskTemplate::BASEWEEK["日"].to_date
           task_templates = current_user.task_templates.where(start_date: from..to)
-          # debugger
         end
 
         if task_templates.empty?


### PR DESCRIPTION
Close #41

開発環境と本番環境用の dockerfile にタイムゾーンの環境変数を指定しました