### PR TITLE
Edit application design （カラーパレットのv-menu に min-width を追加 )

### DIFF
--- a/front/components/Form/SelectorColor.vue
+++ b/front/components/Form/SelectorColor.vue
@@ -4,6 +4,7 @@
     :close-on-content-click="false"
     transition="scale-transition"
     offset-y
+    min-width="150px"
   >
     <template v-slot:activator="{ attrs }">
       <v-text-field


### PR DESCRIPTION
以下を修正

・カラーパレットの v-menu に min-width 150px(カラーパレットと同じ値) を追加
　（viewport xs 時に、カラーパレットの表示領域の右隣に半透明な v-menu 要素が表示されたため）